### PR TITLE
fix segment_long issue with short windows

### DIFF
--- a/deepsegment/deepsegment.py
+++ b/deepsegment/deepsegment.py
@@ -115,7 +115,7 @@ class DeepSegment():
         prefix = []
         while sent:
             current_n_window = n_window - len(prefix)
-            if current_n_window == 0:
+            if current_n_window <= 0:
                 current_n_window = n_window
 
             window = prefix + sent[:current_n_window]


### PR DESCRIPTION
it may be the case that len(prefix)>n_window if just one segment exists in the current window
example fixed: 
segmenter.segment_long("so you were thinking about drinking six drinks on your birthday is that still an accurate number yeah about that i'd say", n_window=4)