### PR TITLE
Change input type checker

### DIFF
--- a/deepsegment/deepsegment.py
+++ b/deepsegment/deepsegment.py
@@ -198,7 +198,7 @@ class DeepSegment():
             print('Please load the model first')
 
         string_output = False
-        if not isinstance(sents, list):
+        if isinstance(sents, str):
             logging.warn("Batch input strings for faster inference.")
             string_output = True
             sents = [sents]


### PR DESCRIPTION
When user insert list-like input such as `tuple of str`,  the line [204](https://github.com/bedapudi6788/deepsegment/blob/b816c2d451cabd870c6c41cdefd228901d0f7c8e/deepsegment/deepsegment.py#L204) transforms input as nested list form. To prevent such cases, the input must be wrapped with a list only when the input is str.